### PR TITLE
Move scan button to profile

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,7 +4,6 @@ import {
     ActivityIndicator,
     ScrollView,
     Image,
-    TouchableOpacity,
     FlatList,
 } from "react-native";
 import { useRouter } from "expo-router";
@@ -48,14 +47,8 @@ const Index = () => {
                 showsVerticalScrollIndicator={false}
                 contentContainerStyle={{ minHeight: "100%", paddingBottom: 10 }}
             >
-                <View className="flex-row mt-20 mb-5 items-center justify-between">
+                <View className="flex-row mt-20 mb-5 items-center justify-center">
                     <Image source={icons.logo} className="w-12 h-10" />
-                    <TouchableOpacity
-                        onPress={() => router.push("/scan")}
-                        className="p-2 rounded-full bg-secondary"
-                    >
-                        <Image source={icons.scan} className="w-6 h-6" />
-                    </TouchableOpacity>
                 </View>
 
                 {moviesLoading || trendingLoading ? (

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,10 +2,11 @@ import { icons } from "@/constants/icons";
 import { View, Text, Image, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAuth } from "@/contexts/AuthContext";
-import { Redirect } from "expo-router";
+import { Redirect, useRouter } from "expo-router";
 
 const Profile = () => {
     const { user, logOut } = useAuth();
+    const router = useRouter();
 
     if (!user) return <Redirect href="/login" />;
 
@@ -17,6 +18,13 @@ const Profile = () => {
                     {user.name}
                 </Text>
                 <Text className="text-gray-500">{user.email}</Text>
+
+                <TouchableOpacity
+                    className="bg-secondary px-5 py-2 rounded-md"
+                    onPress={() => router.push("/scan")}
+                >
+                    <Text className="text-primary font-semibold">Scan</Text>
+                </TouchableOpacity>
 
                 <TouchableOpacity
                     className="bg-secondary px-5 py-2 rounded-md mt-4"


### PR DESCRIPTION
## Summary
- move scan navigation button from index to profile screen

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unable to resolve module 'expo-camera' and 'expo-linear-gradient')

------
https://chatgpt.com/codex/tasks/task_e_68ab0dd198808320a5e07e6e3fa55f1f