### PR TITLE
refactor: replace movie labels with match

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -65,13 +65,13 @@ const Index = () => {
                             onPress={() => {
                                 router.push("/search");
                             }}
-                            placeholder="Search for a movie"
+                            placeholder="Search for a match"
                         />
 
                         {trendingMovies && (
                             <View className="mt-10">
                                 <Text className="text-lg text-white font-bold mb-3">
-                                    Trending Movies
+                                    Trending Matches
                                 </Text>
                                 <FlatList
                                     horizontal
@@ -92,7 +92,7 @@ const Index = () => {
 
                         <>
                             <Text className="text-lg text-white font-bold mt-5 mb-3">
-                                Latest Movies
+                                Latest Matches
                             </Text>
 
                             <FlatList

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -72,7 +72,7 @@ const Search = () => {
 
                         <View className="my-5">
                             <SearchBar
-                                placeholder="Search for a movie"
+                                placeholder="Search for a match"
                                 value={searchQuery}
                                 onChangeText={handleSearch}
                             />
@@ -108,8 +108,8 @@ const Search = () => {
                         <View className="mt-10 px-5">
                             <Text className="text-center text-gray-500">
                                 {searchQuery.trim()
-                                    ? "No movies found"
-                                    : "Start typing to search for movies"}
+                                    ? "No matches found"
+                                    : "Start typing to search for matches"}
                             </Text>
                         </View>
                     ) : null

--- a/components/MovieCard.tsx
+++ b/components/MovieCard.tsx
@@ -39,7 +39,7 @@ const MovieCard = ({
                         {release_date?.split("-")[0]}
                     </Text>
                     <Text className="text-xs font-medium text-light-300 uppercase">
-                        Movie
+                        Match
                     </Text>
                 </View>
             </TouchableOpacity>


### PR DESCRIPTION
## Summary
- update home screen sections and search placeholder to use "match"
- rename search screen messaging to reference matches instead of movies
- change movie card category tag from Movie to Match

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab1648165c83208109e16d8a7e11c0